### PR TITLE
Fix 'stamps/merge-newlib-nano' in canadian cross

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -516,7 +516,7 @@ stamps/build-newlib-nano: $(NEWLIB_SRCDIR) stamps/build-gcc-newlib-stage1
 stamps/merge-newlib-nano: stamps/build-newlib-nano stamps/build-newlib
 # Copy nano library files into newlib install dir.
 	set -e; \
-        for ml in `$(INSTALL_DIR)/bin/$(NEWLIB_TUPLE)-gcc --print-multi-lib`; \
+    for ml in `$(NEWLIB_CC_FOR_TARGET) --print-multi-lib`; \
 	do \
 	    mld=`echo $${ml} | sed -e 's/;.*$$//'`; \
 	    cp $(builddir)/install-newlib-nano/$(NEWLIB_TUPLE)/lib/$${mld}/libc.a \


### PR DESCRIPTION
The above make target executes the just built GCC to print newlib files. In canadian cross, build system cannot execute the built host GCC bin. Since canadian cross already needs standard cross-compile output binaries, use such GCC expoliting PATH env var.