### PR TITLE
Fix small typo in printing out help information for riscv32-unknown-elf-gcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ certain subsets e.g. hardware loops. Do it like this:
 
 * `riscv32-unknown-elf-gcc -march=rv32imfc_xpulpv3 -mno-pulp-hwloop FILES`
 
-Check `riscv32-unknown-elf-gcc --target=help` for more such switches.
+Check `riscv32-unknown-elf-gcc --target-help` for more such switches.


### PR DESCRIPTION
Small typo in `README.md`, now fixed by switching out the `=` for a `-`